### PR TITLE
Include the base color when updating signs (requires 1.14.3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ configurations {
 }
 
 dependencies {
-	compileOnly 'org.bukkit:bukkit:1.14.2-R0.1-SNAPSHOT'
+	compileOnly 'org.bukkit:bukkit:1.14.3-R0.1-SNAPSHOT'
 	compileOnly 'com.comphenix.protocol:ProtocolLib:4.4.0'
 	shade 'org.bstats:bstats-bukkit:1.5'
 }

--- a/src/main/java/de/blablubbabc/insigns/InSigns.java
+++ b/src/main/java/de/blablubbabc/insigns/InSigns.java
@@ -10,7 +10,6 @@ import java.util.List;
 
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
-import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -239,7 +238,7 @@ public class InSigns extends JavaPlugin implements Listener {
 				// send sign update:
 				Player player = event.getPlayer();
 				Sign sign = (Sign) block.getState();
-				player.sendSignChange(sign.getLocation(), sign.getLines(), sign.getColor() == null ? DyeColor.BLACK : sign.getColor());
+				player.sendSignChange(sign.getLocation(), sign.getLines(), Utils.getSignTextColor(sign));
 			}
 		}
 	}
@@ -259,7 +258,7 @@ public class InSigns extends JavaPlugin implements Listener {
 					for (Sign sign : nearbySigns) {
 						if (Utils.isSign(sign.getBlock().getType())) {
 							// still a sign there, send update:
-							player.sendSignChange(sign.getLocation(), sign.getLines(), sign.getColor() == null ? DyeColor.BLACK : sign.getColor());
+							player.sendSignChange(sign.getLocation(), sign.getLines(), Utils.getSignTextColor(sign));
 						}
 					}
 				}

--- a/src/main/java/de/blablubbabc/insigns/InSigns.java
+++ b/src/main/java/de/blablubbabc/insigns/InSigns.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
+import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -238,7 +239,7 @@ public class InSigns extends JavaPlugin implements Listener {
 				// send sign update:
 				Player player = event.getPlayer();
 				Sign sign = (Sign) block.getState();
-				player.sendSignChange(sign.getLocation(), sign.getLines());
+				player.sendSignChange(sign.getLocation(), sign.getLines(), sign.getColor() == null ? DyeColor.BLACK : sign.getColor());
 			}
 		}
 	}
@@ -258,7 +259,7 @@ public class InSigns extends JavaPlugin implements Listener {
 					for (Sign sign : nearbySigns) {
 						if (Utils.isSign(sign.getBlock().getType())) {
 							// still a sign there, send update:
-							player.sendSignChange(sign.getLocation(), sign.getLines());
+							player.sendSignChange(sign.getLocation(), sign.getLines(), sign.getColor() == null ? DyeColor.BLACK : sign.getColor());
 						}
 					}
 				}

--- a/src/main/java/de/blablubbabc/insigns/Utils.java
+++ b/src/main/java/de/blablubbabc/insigns/Utils.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.bukkit.Chunk;
+import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -23,6 +24,13 @@ public class Utils {
 		if (material == null) return false;
 		return (material.data == org.bukkit.block.data.type.Sign.class)
 				|| (material.data == org.bukkit.block.data.type.WallSign.class);
+	}
+
+	// returns the sign's text color, or the default
+	public static DyeColor getSignTextColor(org.bukkit.block.Sign sign) {
+		assert sign != null;
+		DyeColor color = sign.getColor(); // can be null
+		return (color != null) ? color : DyeColor.BLACK; // default: black
 	}
 
 	public static <T extends BlockState> List<T> getNearbyTileEntities(Location location, int chunkRadius, Class<T> type) {


### PR DESCRIPTION
This change includes the base color of signs when resending them, so the text will not look black when the sign was dyed. The API for this was quite recently added to spigot, so it will break for older builds.