### PR TITLE
Fix a NPE when handling the TileEntityData packet

### DIFF
--- a/src/main/java/de/blablubbabc/insigns/SignPacketListeners.java
+++ b/src/main/java/de/blablubbabc/insigns/SignPacketListeners.java
@@ -71,7 +71,7 @@ class SignPacketListeners {
 		Location location = new Location(player.getWorld(), blockPosition.getX(), blockPosition.getY(), blockPosition.getZ());
 		NbtCompound signData = ProtocolUtils.Packet.TileEntityData.getTileEntityData(packet);
 		// TODO Identify the tile entity type based on the BlockEntityType stored by the packet.
-		if (!ProtocolUtils.TileEntity.Sign.isTileEntitySignData(signData)) {
+		if (signData == null || !ProtocolUtils.TileEntity.Sign.isTileEntitySignData(signData)) {
 			return; // Ignore
 		}
 		String[] rawLines = ProtocolUtils.TileEntity.Sign.getText(signData);


### PR DESCRIPTION
I rarely got this exception: https://cpaste.de/ayuzixavir.properties - Looks like sometimes the tile entity data is just null. This PR fixes it by just skipping those empty tile entity data packets.