### PR TITLE
Update for Minecraft 1.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ configurations {
 }
 
 dependencies {
-	compileOnly 'org.spigotmc:spigot-api:1.18.1-R0.1-SNAPSHOT'
-	compileOnly 'com.comphenix.protocol:ProtocolLib:4.8.0-SNAPSHOT'
+	compileOnly 'org.spigotmc:spigot-api:1.20.1-R0.1-SNAPSHOT'
+	compileOnly 'com.comphenix.protocol:ProtocolLib:5.0.0'
 	shade 'org.bstats:bstats-bukkit:2.2.1'
 }
 

--- a/src/main/java/de/blablubbabc/insigns/InSigns.java
+++ b/src/main/java/de/blablubbabc/insigns/InSigns.java
@@ -95,8 +95,8 @@ public class InSigns extends JavaPlugin {
 		}, delayTicks);
 	}
 
-	SignSendEvent callSignSendEvent(Player player, Location location, String[] rawLines) {
-		SignSendEvent signSendEvent = new SignSendEvent(player, location, rawLines);
+	SignSendEvent callSignSendEvent(Player player, Location location, String[] rawLinesFront, String[] rawLinesBack) {
+		SignSendEvent signSendEvent = new SignSendEvent(player, location, rawLinesFront, rawLinesBack);
 		Bukkit.getPluginManager().callEvent(signSendEvent);
 		return signSendEvent;
 	}

--- a/src/main/java/de/blablubbabc/insigns/SignSendEvent.java
+++ b/src/main/java/de/blablubbabc/insigns/SignSendEvent.java
@@ -6,6 +6,7 @@ package de.blablubbabc.insigns;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.block.sign.Side;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.Event;
@@ -18,15 +19,17 @@ public class SignSendEvent extends Event implements Cancellable {
 
 	private final Player player;
 	private final Location location;
-	private String[] lines;
+	private String[] linesFront;
+	private String[] linesBack;
 	private boolean modified = false;
 	private boolean cancelled = false;
 
-	SignSendEvent(Player player, Location location, String[] lines) {
+	SignSendEvent(Player player, Location location, String[] linesFront, String[] linesBack) {
 		super(!Bukkit.isPrimaryThread());
 		this.player = player;
 		this.location = location;
-		this.lines = lines;
+		this.linesFront = linesFront;
+		this.linesBack = linesBack;
 	}
 
 	/**
@@ -58,14 +61,37 @@ public class SignSendEvent extends Event implements Cancellable {
 	 * @throws IndexOutOfBoundsException
 	 *             when trying to access a line that does not exist
 	 */
+	@Deprecated(forRemoval = true)
 	public String getLine(int index) throws IndexOutOfBoundsException {
-		return lines[index];
+		return getLine(Side.FRONT, index);
+	}
+
+
+	/**
+	 * Gets the sign text at the line with the specified index.
+	 * <p>
+	 * This is the raw line content as it is contained in the corresponding sign update packet.
+	 * 
+	 * @param side
+	 *            the side to get the text from
+	 * @param index
+	 *            the line number to get the text from, starting at 0
+	 * @return the sign text for the specified line
+	 * @throws IndexOutOfBoundsException
+	 *             when trying to access a line that does not exist
+	 */
+	public String getLine(Side side, int index) throws IndexOutOfBoundsException {
+		return getLines(side)[index];
 	}
 
 	// Non-API method: Plugins should not modify the String array directly because we want to keep track if the lines
 	// were modified.
-	String[] getLines() {
-		return lines;
+	String[] getLines(Side side) {
+		return switch (side) {
+			case FRONT -> linesFront;
+			case BACK -> linesBack;
+			default -> throw new IllegalArgumentException("side");
+		};
 	}
 
 	/**
@@ -89,8 +115,28 @@ public class SignSendEvent extends Event implements Cancellable {
 	 * @throws IndexOutOfBoundsException
 	 *             when trying to access a line that does not exist
 	 */
+	@Deprecated(forRemoval = true)
 	public void setLine(int index, String line) throws IndexOutOfBoundsException {
+		setLine(Side.FRONT, index, line);
+	}
+
+	/**
+	 * Sets the sign text at the line with the specified index.
+	 * <p>
+	 * This expects the raw line content as it would be contained in the corresponding packet.
+	 * 
+	 * @param side
+	 *            the side to set the text at
+	 * @param index
+	 *            the line number to set the text at, starting at 0
+	 * @param line
+	 *            the new text for the specified line
+	 * @throws IndexOutOfBoundsException
+	 *             when trying to access a line that does not exist
+	 */
+	public void setLine(Side side, int index, String line) throws IndexOutOfBoundsException {
 		if (line == null) line = "";
+		String[] lines = getLines(side);
 		// Ignore if the line did not actually change:
 		if (line.equals(lines[index])) return;
 

--- a/src/main/java/de/blablubbabc/insigns/SimpleChanger.java
+++ b/src/main/java/de/blablubbabc/insigns/SimpleChanger.java
@@ -7,6 +7,7 @@ package de.blablubbabc.insigns;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
+import org.bukkit.block.sign.Side;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -91,17 +92,19 @@ public class SimpleChanger implements Listener {
 	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
 	public void onSignSend(SignSendEvent event) {
 		String value = null;
-		for (int i = 0; i < 4; i++) {
-			String line = event.getLine(i);
-			if (line.contains(key)) {
-				if (value == null) {
-					value = this.getValue(event.getPlayer(), event.getLocation(), key);
-					// Ensure that the value is no longer null so that we request it at most once per sent sign:
+		for (Side side : Side.values()) {
+			for (int i = 0; i < 4; i++) {
+				String line = event.getLine(side, i);
+				if (line.contains(key)) {
 					if (value == null) {
-						value = "null";
+						value = this.getValue(event.getPlayer(), event.getLocation(), key);
+						// Ensure that the value is no longer null so that we request it at most once per sent sign:
+						if (value == null) {
+							value = "null";
+						}
 					}
+					event.setLine(side, i, line.replace(key, value));
 				}
-				event.setLine(i, line.replace(key, value));
 			}
 		}
 	}

--- a/src/main/java/de/blablubbabc/insigns/Utils.java
+++ b/src/main/java/de/blablubbabc/insigns/Utils.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.bukkit.Chunk;
-import org.bukkit.DyeColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -39,20 +38,6 @@ public final class Utils {
 	}
 
 	/**
-	 * Gets the sign's text color, or the default {@link DyeColor#BLACK} if no text color is explicitly set for the
-	 * sign.
-	 * 
-	 * @param sign
-	 *            the sign
-	 * @return the sign's text color, not <code>null</code>
-	 */
-	public static DyeColor getSignTextColor(org.bukkit.block.Sign sign) {
-		Preconditions.checkNotNull(sign, "sign is null");
-		DyeColor color = sign.getColor(); // Can be null
-		return (color != null) ? color : DyeColor.BLACK; // Default: Black
-	}
-
-	/**
 	 * Sends the a sign update packet for the given sign to the specified player.
 	 * 
 	 * @param player
@@ -63,7 +48,7 @@ public final class Utils {
 	public static void sendSignUpdate(Player player, org.bukkit.block.Sign sign) {
 		Preconditions.checkNotNull(player, "player is null");
 		Preconditions.checkNotNull(sign, "sign is null");
-		player.sendSignChange(sign.getLocation(), sign.getLines(), getSignTextColor(sign), sign.isGlowingText());
+		player.sendBlockUpdate(sign.getLocation(), sign);
 	}
 
 	/**


### PR DESCRIPTION
I updated the SignSendEvent to have new methods that include the side of the sign when getting/setting lines. I think this is better than having two events (one for each side), because both sides are always sent together (and otherwise cancelling one of the events could be confusing). The downside is that it requires updating the handlers for this event if they want to modify the back side of signs.

ProtocolLib now has a getBlockEntityTypeModifier(), but it always returns "minecraft:furnace" for signs, so I kept the old sign detection by inspecting the NBT.

This update requires Minecraft 1.20 because of the large changes.